### PR TITLE
feat: add CLI script to publish posts

### DIFF
--- a/agent/task/2025/09/01/1247-create-post-script.md
+++ b/agent/task/2025/09/01/1247-create-post-script.md
@@ -1,0 +1,15 @@
+# Task: create post script
+
+## Summary
+
+Implemented CLI script to publish posts to Telegram channel via grammY.
+
+## Observations
+
+- Manual dependency wiring used because @teqfw/di package was not accessible.
+- Script expects BOT_TOKEN and CHANNEL_ID in environment.
+
+## Suggestions
+
+- Replace manual wiring with real @teqfw/di container.
+- Add unit tests for publish handler.

--- a/bin/post.js
+++ b/bin/post.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import Tg_Post_Back_Repo_Config from "../src/back/Tg_Post_Back_Repo_Config.js";
+import Tg_Post_Back_Bot_Client from "../src/back/Tg_Post_Back_Bot_Client.js";
+import Tg_Post_Back_Handler_Publish from "../src/back/Tg_Post_Back_Handler_Publish.js";
+import Tg_Post_Back_Cli_Post from "../src/back/Tg_Post_Back_Cli_Post.js";
+import Tg_Post_Shared_Dto_Post from "../src/shared/Tg_Post_Shared_Dto_Post.js";
+
+async function main() {
+  const repoConfig = new Tg_Post_Back_Repo_Config();
+  const botClient = new Tg_Post_Back_Bot_Client(repoConfig);
+  const handler = new Tg_Post_Back_Handler_Publish(botClient);
+  const cli = new Tg_Post_Back_Cli_Post(handler, Tg_Post_Shared_Dto_Post);
+  await cli.run(process.argv);
+}
+
+main().catch((err) => {
+  console.error("Publishing failed:", err);
+  process.exit(1);
+});
+
+// AGENT: replace manual wiring with @teqfw/di container when available

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "tg:check": "node src/check-telegram.js",
+    "tg:post": "node bin/post.js",
     "test": "echo \"No tests yet\""
   },
   "dependencies": {

--- a/src/back/Tg_Post_Back_Bot_Client.js
+++ b/src/back/Tg_Post_Back_Bot_Client.js
@@ -1,0 +1,18 @@
+import { Bot } from "grammy";
+
+export default class Tg_Post_Back_Bot_Client {
+  constructor(repoConfig) {
+    this.repoConfig = repoConfig;
+    const token = this.repoConfig.getBotToken();
+    if (!token) throw new Error("BOT_TOKEN is not defined");
+    this.bot = new Bot(token);
+  }
+
+  async sendMessage(text) {
+    await this.bot.api.sendMessage(this.repoConfig.getChannelId(), text);
+  }
+
+  async sendPhoto(url, caption) {
+    await this.bot.api.sendPhoto(this.repoConfig.getChannelId(), url, { caption });
+  }
+}

--- a/src/back/Tg_Post_Back_Cli_Post.js
+++ b/src/back/Tg_Post_Back_Cli_Post.js
@@ -1,0 +1,17 @@
+export default class Tg_Post_Back_Cli_Post {
+  constructor(handler, DtoPost) {
+    this.handler = handler;
+    this.DtoPost = DtoPost;
+  }
+
+  async run(argv) {
+    const [text, image] = argv.slice(2);
+    if (!text) {
+      console.error("Usage: node bin/post.js <text> [image]");
+      process.exit(1);
+    }
+    const dto = new this.DtoPost({ text, image });
+    await this.handler.publish(dto);
+    console.log("Post published.");
+  }
+}

--- a/src/back/Tg_Post_Back_Handler_Publish.js
+++ b/src/back/Tg_Post_Back_Handler_Publish.js
@@ -1,0 +1,13 @@
+export default class Tg_Post_Back_Handler_Publish {
+  constructor(botClient) {
+    this.botClient = botClient;
+  }
+
+  async publish(dto) {
+    if (dto.image) {
+      await this.botClient.sendPhoto(dto.image, dto.text);
+    } else {
+      await this.botClient.sendMessage(dto.text);
+    }
+  }
+}

--- a/src/back/Tg_Post_Back_Repo_Config.js
+++ b/src/back/Tg_Post_Back_Repo_Config.js
@@ -1,0 +1,13 @@
+import { config } from "dotenv";
+
+config();
+
+export default class Tg_Post_Back_Repo_Config {
+  getBotToken() {
+    return process.env.BOT_TOKEN;
+  }
+
+  getChannelId() {
+    return process.env.CHANNEL_ID;
+  }
+}

--- a/src/shared/Tg_Post_Shared_Dto_Post.js
+++ b/src/shared/Tg_Post_Shared_Dto_Post.js
@@ -1,0 +1,6 @@
+export default class Tg_Post_Shared_Dto_Post {
+  constructor({ text, image }) {
+    this.text = text;
+    this.image = image;
+  }
+}


### PR DESCRIPTION
## Summary
- add configuration repository and bot client classes
- implement publish handler and CLI tool to send posts
- wire modules in new `bin/post.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5958b20c8832dbc55f8864d51ddb5